### PR TITLE
Modify Migrations templates to use default base64 LSN value

### DIFF
--- a/lib/electric/migrations/templates/satellite.sql.eex
+++ b/lib/electric/migrations/templates/satellite.sql.eex
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS _electric_migrations (
 );
 
 -- Initialisation of the metadata table
-INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', '0');
+INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'MA==');
 <% end %>
 
 -- These are toggles for turning the triggers on and off

--- a/test/migration_test.exs
+++ b/test/migration_test.exs
@@ -133,7 +133,7 @@ defmodule MigrationsTest do
       );
 
       -- Initialisation of the metadata table
-      INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', '0');
+      INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'MA==');
 
 
       -- These are toggles for turning the triggers on and off


### PR DESCRIPTION
changed from string '0' to its base64 representation

Closes vax-363