### PR TITLE
 Add a persistent client id

### DIFF
--- a/lib/electric/client.ex
+++ b/lib/electric/client.ex
@@ -7,7 +7,6 @@ defmodule Electric.Client do
   alias Electric.Session.Credentials
 
   alias Electric.Util
-  alias Electric.Progress
 
   @default_base_url "https://console.electric-sql.com/api/v1/"
 

--- a/lib/electric/migrations/migrations.ex
+++ b/lib/electric/migrations/migrations.ex
@@ -212,8 +212,8 @@ defmodule Electric.Migrations do
       |> Enum.map(&Enum.take(read_migrations, &1))
       |> Enum.reduce_while({:ok, ""}, fn subset, {_status, messages} ->
         case add_triggers_to_migration(subset, template) do
-          {:ok, warning_message} -> {:cont, {:ok, "#{messages}#{warning_message}"}}
           {:ok, nil} -> {:cont, {:ok, messages}}
+          {:ok, warning_message} -> {:cont, {:ok, "#{messages}#{warning_message}"}}
           {:error, reason} -> {:halt, {:error, reason}}
         end
       end)

--- a/lib/electric/migrations/templates/satellite.sql.eex
+++ b/lib/electric/migrations/templates/satellite.sql.eex
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS _electric_migrations (
 );
 
 -- Initialisation of the metadata table
-INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'MA==');
+INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'MA=='), ('clientId', '');
 <% end %>
 
 -- These are toggles for turning the triggers on and off

--- a/lib/electric/migrations/templates/satellite.sql.eex
+++ b/lib/electric/migrations/templates/satellite.sql.eex
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS _electric_oplog (
 
 -- Somewhere to keep our metadata
 CREATE TABLE IF NOT EXISTS _electric_meta (
-  key TEXT,
+  key TEXT PRIMARY KEY,
   value BLOB
 );
 

--- a/test/migration_test.exs
+++ b/test/migration_test.exs
@@ -120,7 +120,7 @@ defmodule MigrationsTest do
 
       -- Somewhere to keep our metadata
       CREATE TABLE IF NOT EXISTS _electric_meta (
-        key TEXT,
+        key TEXT PRIMARY KEY,
         value BLOB
       );
 
@@ -133,7 +133,7 @@ defmodule MigrationsTest do
       );
 
       -- Initialisation of the metadata table
-      INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'MA==');
+      INSERT INTO _electric_meta (key, value) VALUES ('compensations', 0), ('lastAckdRowId','0'), ('lastSentRowId', '0'), ('lsn', 'MA=='), ('clientId', '');
 
 
       -- These are toggles for turning the triggers on and off


### PR DESCRIPTION
see https://github.com/electric-sql/typescript-client/pull/25

> The replication system needs a consistent client id as part of the authentication call. This PR creates a persistent per-client UUID as part of the satellite metadata on startup and passes it to the authentication message