### PR TITLE
mix: fix invalid version string.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Electric.MixProject do
   def project do
     [
       app: :electric_sql_cli,
-      version: git_version(),
+      version: "0.1.0-#{git_version()}",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
As per https://hexdocs.pm/elixir/Version.html, the mix.exs project `:version` string can't just be a hash, it needs to follow `major.minor.patch[-pre][(.build)*]`.