### PR TITLE
Thruflo/print new migration path

### DIFF
--- a/lib/electric/commands/migrations.ex
+++ b/lib/electric/commands/migrations.ex
@@ -168,8 +168,8 @@ defmodule Electric.Commands.Migrations do
 
       Electric.Progress.run("Creating new migration", fn ->
         case Electric.Migrations.new_migration(args.migration_title, options) do
-          {:ok, nil} ->
-            {:success, "New migration created"}
+          {:ok, migration_file_path} ->
+            {:success, "New migration created at:\n#{migration_file_path}"}
 
           {:error, errors} ->
             {:error, format_messages("errors", errors)}

--- a/lib/electric/migrations/migrations.ex
+++ b/lib/electric/migrations/migrations.ex
@@ -371,7 +371,7 @@ defmodule Electric.Migrations do
     File.write!(migration_file_path, body)
     add_migration_to_manifest(migrations_folder, migration_name, migration_title, body, app_id)
 
-    {:ok, nil}
+    {:ok, migration_file_path}
   end
 
   def get_template() do

--- a/test/migration_test.exs
+++ b/test/migration_test.exs
@@ -1319,5 +1319,18 @@ defmodule MigrationsFileTest do
 
       assert reverted_body == expected
     end
+
+    test "new migration returns `{:ok, migration_file_path}`" do
+      temp = temp_folder()
+      migrations_dir = Path.join([temp, "migrations"])
+      opts = %{migrations_dir: migrations_dir}
+
+      {:ok, _msg} = Electric.Migrations.init_migrations("test_app", opts)
+      assert {:ok, file_path} = Electric.Migrations.new_migration("another", opts)
+
+      assert is_binary(file_path)
+      assert String.starts_with?(file_path, migrations_dir)
+      assert String.ends_with?(file_path, "migration.sql")
+    end
   end
 end


### PR DESCRIPTION
It's nice to print the file path to `migration.sql` when creating a new migration. So:

```sh
electric migrations new "create items"
Done.
New migration created at:
/Users/thruflo/Development/sandbox/quickstart/migrations/20221231_140458_659_create_items/migration.sql
```

As opposed to just:

```sh
electric migrations new "create items"
Done.
New migration created
```

N.b.: based off `thruflo/valid-version-string` because git push fails otherwise.