### PR TITLE
config: support configuring console connection details.

### DIFF
--- a/apps/electric_cli/lib/electric_cli/config/console.ex
+++ b/apps/electric_cli/lib/electric_cli/config/console.ex
@@ -1,0 +1,15 @@
+defmodule ElectricCli.Config.Console do
+  @derive Jason.Encoder
+  @type t() :: %__MODULE__{
+          host: binary(),
+          port: integer(),
+          ssl: boolean()
+        }
+  defstruct [
+    :host,
+    :port,
+    :ssl
+  ]
+
+  use ExConstructor
+end

--- a/apps/electric_cli/lib/electric_cli/config/environment.ex
+++ b/apps/electric_cli/lib/electric_cli/config/environment.ex
@@ -1,17 +1,22 @@
 defmodule ElectricCli.Config.Environment do
+  alias ElectricCli.Config.Console
   alias ElectricCli.Config.Replication
+  alias ElectricCli.Util
+  alias __MODULE__
 
   @derive {Jason.Encoder, except: [:slug]}
-  @type t() :: %__MODULE__{
-          slug: binary(),
-          replication: %Replication{}
+  @type t() :: %Environment{
+          console: %Console{},
+          replication: %Replication{},
+          slug: binary()
         }
   @enforce_keys [
     :slug
   ]
   defstruct [
-    :slug,
-    :replication
+    :console,
+    :replication,
+    :slug
   ]
 
   use ExConstructor
@@ -35,6 +40,16 @@ defmodule ElectricCli.Config.Environment do
   def new(map) do
     struct = super(map)
 
+    console =
+      case struct.console do
+        nil ->
+          nil
+
+        alt ->
+          alt
+          |> Console.new()
+      end
+
     replication =
       case struct.replication do
         nil ->
@@ -45,6 +60,59 @@ defmodule ElectricCli.Config.Environment do
           |> Replication.new()
       end
 
-    %{struct | replication: replication}
+    %{struct | console: console, replication: replication}
+  end
+
+  @doc """
+  Dry up some messy logic where we set the console and replication config
+  for an environment, based on whether the values have been configured.
+
+  We could dry up further by using the same struct for %Config{} and %Replication{}
+  but this might bite us if the signature of the configured info needs to
+  diverge in future.
+  """
+  @spec put_optional(
+          %Environment{},
+          :console | :replication,
+          binary() | nil,
+          integer() | nil,
+          boolean()
+        ) :: %Environment{}
+  def put_optional(environment, key, host_option, port_option, disable_ssl_flag \\ false) do
+    should_set_host = not is_nil(host_option)
+    should_set_port = not is_nil(port_option)
+    should_set_sql = should_set_host
+
+    default =
+      case key do
+        :console -> %Console{}
+        :replication -> %Replication{}
+      end
+
+    struct =
+      case Map.get(environment, key) do
+        nil ->
+          default
+
+        ^default = val ->
+          val
+      end
+
+    struct =
+      struct
+      |> Util.map_put_if(:host, host_option, should_set_host)
+      |> Util.map_put_if(:port, port_option, should_set_port)
+      |> Util.map_put_if(:ssl, not disable_ssl_flag, should_set_sql)
+
+    is_empty? =
+      struct
+      |> Map.from_struct()
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Enum.empty?()
+
+    {is_empty?, struct}
+
+    environment
+    |> Util.map_put_if(key, struct, not is_empty?)
   end
 end

--- a/apps/electric_cli/lib/electric_cli/options.ex
+++ b/apps/electric_cli/lib/electric_cli/options.ex
@@ -53,6 +53,33 @@ defmodule ElectricCli.Options do
     ]
   end
 
+  def console_flags do
+    [
+      console_disable_ssl: [
+        long: "--console-disable-ssl",
+        help: "Connect to the console service without using SSL.",
+        required: false
+      ]
+    ]
+  end
+
+  def console_options do
+    [
+      console_host: [
+        long: "--console-host",
+        value_name: "ADDRESS",
+        help: "Console service host.",
+        parser: :string
+      ],
+      console_port: [
+        long: "--console-port",
+        value_name: "PORT",
+        help: "Console service port. Defaults to 443 if not specified.",
+        parser: :integer
+      ]
+    ]
+  end
+
   def directory_options(populate_defaults \\ true) do
     default_migrations_dir =
       case populate_defaults do

--- a/apps/electric_cli/test/electric_cli/commands/config_test.exs
+++ b/apps/electric_cli/test/electric_cli/commands/config_test.exs
@@ -2,6 +2,7 @@ defmodule ElectricCli.Commands.ConfigTest do
   use ElectricCli.CommandCase, async: false
 
   alias ElectricCli.Config
+  alias ElectricCli.Config.Console
   alias ElectricCli.Config.Environment
   alias ElectricCli.Config.Replication
 
@@ -189,6 +190,22 @@ defmodule ElectricCli.Commands.ConfigTest do
       })
     end
 
+    test "sets console data if provided", %{tmp_dir: root} = ctx do
+      args =
+        argv(ctx, [
+          "--console-disable-ssl",
+          "--console-host",
+          "localhost",
+          "--console-port",
+          "8080"
+        ])
+
+      assert {{:ok, _output}, _} = run_cmd(args)
+
+      {:ok, %Config{environments: %{default: %Environment{} = environment}}} = Config.load(root)
+      assert %{console: %Console{host: "localhost", port: 8080, ssl: false}} = environment
+    end
+
     test "sets replication data if provided", %{tmp_dir: root} = ctx do
       args =
         argv(ctx, [
@@ -200,9 +217,9 @@ defmodule ElectricCli.Commands.ConfigTest do
         ])
 
       assert {{:ok, _output}, _} = run_cmd(args)
-      assert {:ok, %Config{environments: environments}} = Config.load(root)
-      assert %Environment{replication: replication} = Map.get(environments, :default)
-      assert %Replication{host: "localhost", port: 5133, ssl: false} = replication
+
+      {:ok, %Config{environments: %{default: %Environment{} = environment}}} = Config.load(root)
+      assert %{replication: %Replication{host: "localhost", port: 5133, ssl: false}} = environment
     end
   end
 
@@ -285,6 +302,23 @@ defmodule ElectricCli.Commands.ConfigTest do
       assert link_target == Path.join(app, "staging")
     end
 
+    test "sets console data if provided", %{tmp_dir: root} = ctx do
+      args =
+        argv(ctx, [
+          "staging",
+          "--console-disable-ssl",
+          "--console-host",
+          "localhost",
+          "--console-port",
+          "8080"
+        ])
+
+      assert {{:ok, _output}, _} = run_cmd(args)
+
+      {:ok, %Config{environments: %{staging: %Environment{} = environment}}} = Config.load(root)
+      assert %{console: %Console{host: "localhost", port: 8080, ssl: false}} = environment
+    end
+
     test "sets replication data if provided", %{tmp_dir: root} = ctx do
       args =
         argv(ctx, [
@@ -298,14 +332,8 @@ defmodule ElectricCli.Commands.ConfigTest do
 
       assert {{:ok, _output}, _} = run_cmd(args)
 
-      assert {:ok,
-              %Config{
-                environments: %{
-                  staging: %Environment{
-                    replication: %Replication{host: "localhost", port: 5133, ssl: false}
-                  }
-                }
-              }} = Config.load(root)
+      {:ok, %Config{environments: %{staging: %Environment{} = environment}}} = Config.load(root)
+      assert %{replication: %Replication{host: "localhost", port: 5133, ssl: false}} = environment
     end
   end
 
@@ -343,6 +371,23 @@ defmodule ElectricCli.Commands.ConfigTest do
       assert output =~ "not found"
     end
 
+    test "sets console data if provided", %{tmp_dir: root} = ctx do
+      args =
+        argv(ctx, [
+          "default",
+          "--console-disable-ssl",
+          "--console-host",
+          "localhost",
+          "--console-port",
+          "8080"
+        ])
+
+      assert {{:ok, _output}, _} = run_cmd(args)
+
+      {:ok, %Config{environments: %{default: %Environment{} = environment}}} = Config.load(root)
+      assert %{console: %Console{host: "localhost", port: 8080, ssl: false}} = environment
+    end
+
     test "sets replication data if provided", %{tmp_dir: root} = ctx do
       args =
         argv(ctx, [
@@ -356,14 +401,8 @@ defmodule ElectricCli.Commands.ConfigTest do
 
       assert {{:ok, _output}, _} = run_cmd(args)
 
-      assert {:ok,
-              %Config{
-                environments: %{
-                  default: %Environment{
-                    replication: %Replication{host: "localhost", port: 5133, ssl: false}
-                  }
-                }
-              }} = Config.load(root)
+      {:ok, %Config{environments: %{default: %Environment{} = environment}}} = Config.load(root)
+      assert %{replication: %Replication{host: "localhost", port: 5133, ssl: false}} = environment
     end
   end
 

--- a/apps/electric_cli/test/electric_cli/commands/init_test.exs
+++ b/apps/electric_cli/test/electric_cli/commands/init_test.exs
@@ -2,6 +2,7 @@ defmodule ElectricCli.Commands.InitTest do
   use ElectricCli.CommandCase, async: false
 
   alias ElectricCli.Config
+  alias ElectricCli.Config.Console
   alias ElectricCli.Config.Environment
   alias ElectricCli.Config.Replication
   alias ElectricCli.Manifest
@@ -117,6 +118,23 @@ defmodule ElectricCli.Commands.InitTest do
       assert %Environment{replication: nil} = Map.get(environments, :default)
     end
 
+    test "sets console data if provided", %{tmp_dir: root} = ctx do
+      args =
+        argv(ctx, [
+          "tarragon-envy-1337",
+          "--console-host",
+          "localhost",
+          "--console-port",
+          "8080",
+          "--console-disable-ssl"
+        ])
+
+      assert {{:ok, _output}, _} = run_cmd(args)
+
+      {:ok, %Config{environments: %{default: %Environment{} = environment}}} = Config.load(root)
+      assert %{console: %Console{host: "localhost", port: 8080, ssl: false}} = environment
+    end
+
     test "sets replication data if provided", %{tmp_dir: root} = ctx do
       args =
         argv(ctx, [
@@ -130,9 +148,8 @@ defmodule ElectricCli.Commands.InitTest do
 
       assert {{:ok, _output}, _} = run_cmd(args)
 
-      assert {:ok, %Config{environments: environments}} = Config.load(root)
-      assert %Environment{replication: replication} = Map.get(environments, :default)
-      assert %Replication{host: "localhost", port: 5133, ssl: false} = replication
+      {:ok, %Config{environments: %{default: %Environment{} = environment}}} = Config.load(root)
+      assert %{replication: %Replication{host: "localhost", port: 5133, ssl: false}} = environment
     end
 
     test "creates manifest with one migration", %{tmp_dir: root} = ctx do


### PR DESCRIPTION
Adds support for:

- `--console-host HOST`
- `--console-port PORT`
- `--console-disable-ssl`

To the init and relevant config commands.