### PR TITLE
init and revert: support syncing migrations down.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Creates a new folder for migrations in your current directory called 'migrations
 
 The `APP` and optinally `ENV` you give should be copied from the sync service connection details provided by the ElectricSQL console. You specify here once, and the CLI stores in an `electric.json` file so you don't have to keep re-typing it.
 
+Note that you can also sync down migrations from an existing app using:
+
+```sh
+electric init APP --sync-down
+```
+
 ### Update
 
 You can update your config using `electric config update`. See the options with:
@@ -180,15 +186,31 @@ electric migrations revert NAME [--env ENV]
 
 This will copy the named migration from the ElectricSQL server to replace the local one. By default this will use the `default` environment, if you want to use a different one you can specify it with `--env ENV`.
 
+If you're having problems with your local migrations, you can force revert:
+
+```sh
+electric migrations revert NAME --force
+```
+
+And you can revert all of the local migrations to match the migrations that have been applied on the server. This is like a force reset of the local migrations folder:
+
+```sh
+electric migrations revert --all
+```
+
+Remeber to `electric build` after resetting before importing into your local app.
+
 ### reset
 
-If you get stuck in local development and need to reset your backend, you can wipe and re-provision your environment using:
+> WARNING: Use `reset` with extreme care (and usually only in development) as it explicitly causes data loss.
+
+If you get stuck and need to reset the migrations that have been applied on the server, you can wipe and re-provision your environment using:
 
 ```sh
 electric reset [--env ENV]
 ```
 
-WARNING: Use this with care (and usually only in development) as it explicitly causes data loss.
+This is like a force reset of the server migrations. Remember to `electric sync` to upload your local migrations to the new server environment before restarting replication.
 
 ## Contributing
 

--- a/apps/electric_cli/lib/electric_cli/commands/sync.ex
+++ b/apps/electric_cli/lib/electric_cli/commands/sync.ex
@@ -6,7 +6,7 @@ defmodule ElectricCli.Commands.Sync do
 
   def about() do
     """
-    Sync migrations upto the backend.
+    Sync migrations upto and down from the backend.
 
     This synchronises your local changes up to your ElectricSQL sync service
     and builds a new javascript file at `:output_dir/:app/:env/index.js` that

--- a/apps/electric_cli/lib/electric_cli/commands/sync.ex
+++ b/apps/electric_cli/lib/electric_cli/commands/sync.ex
@@ -6,7 +6,7 @@ defmodule ElectricCli.Commands.Sync do
 
   def about() do
     """
-    Sync migrations upto and down from the backend.
+    Sync migrations up-to the backend.
 
     This synchronises your local changes up to your ElectricSQL sync service
     and builds a new javascript file at `:output_dir/:app/:env/index.js` that
@@ -37,6 +37,9 @@ defmodule ElectricCli.Commands.Sync do
 
     The sync will also fail if the migration has a name that is lower in sort order
     than one already applied on the server.
+
+    If you want to sync migrations down from the backend without uploading
+    and matching your local migrations, use `electric revert [NAME] [--all]`.
     """
   end
 

--- a/apps/electric_cli/lib/electric_cli/config.ex
+++ b/apps/electric_cli/lib/electric_cli/config.ex
@@ -126,9 +126,7 @@ defmodule ElectricCli.Config do
       |> Map.update!(:directories, &contract_directories(&1, root))
       |> Map.update!(:environments, &contract_environments/1)
 
-    config_filepath =
-      root
-      |> filepath()
+    config_filepath = filepath(root)
 
     with {:ok, json} <- Jason.encode(config, pretty: true),
          :ok <- File.write(config_filepath, json <> "\n"),

--- a/apps/electric_cli/lib/electric_cli/core.ex
+++ b/apps/electric_cli/lib/electric_cli/core.ex
@@ -53,7 +53,7 @@ defmodule ElectricCli.Core do
          {:ok, %Manifest{} = manifest, []} <-
            Migrations.hydrate_manifest(manifest, migrations_dir),
          {:ok, dynamic_success_message} <- Sync.sync_migrations(manifest, environment),
-         {:ok, %Manifest{} = server_manifest} <- Api.get_server_migrations(app, env, true),
+         {:ok, %Manifest{} = server_manifest} <- Api.get_server_migrations(app, env, :satellite),
          :ok <- Bundle.write(server_manifest, environment, :server, debug, output_dir) do
       {:ok, dynamic_success_message}
     end

--- a/apps/electric_cli/lib/electric_cli/migrations/api.ex
+++ b/apps/electric_cli/lib/electric_cli/migrations/api.ex
@@ -63,12 +63,14 @@ defmodule ElectricCli.Migrations.Api do
     end
   end
 
-  def get_server_migrations(app, env, with_satellite \\ false) do
+  def get_server_migrations(app, env, body \\ nil) do
     path =
-      if with_satellite do
-        "apps/#{app}/environments/#{env}/migrations?body=satellite"
-      else
-        "apps/#{app}/environments/#{env}/migrations"
+      case body do
+        nil ->
+          "apps/#{app}/environments/#{env}/migrations"
+
+        param ->
+          "apps/#{app}/environments/#{env}/migrations?body=#{param}"
       end
 
     case Client.get(path) do

--- a/apps/electric_cli/test/mocks/mock_server.ex
+++ b/apps/electric_cli/test/mocks/mock_server.ex
@@ -78,6 +78,26 @@ defmodule ElectricCli.MockServer do
         "sha256" => "d0a52f739f137fc80fd67d9fd347cb4097bd6fb182e583f2c64d8de309393ad7",
         "title" => "another"
       }
+    ],
+    "sync-from-1234" => [
+      %{
+        "encoding" => "escaped",
+        "name" => "first_migration_name",
+        "status" => "applied",
+        "original_body" => "",
+        "satellite_body" => ["something random"],
+        "sha256" => "2a97d825e41ae70705381016921c55a3b086a813649e4da8fcba040710055747",
+        "title" => "init"
+      },
+      %{
+        "encoding" => "escaped",
+        "name" => "second_migration_name",
+        "original_body" => "ORIGINAL",
+        "status" => "applied",
+        "satellite_body" => ["other stuff"],
+        "sha256" => "d0a52f739f137fc80fd67d9fd347cb4097bd6fb182e583f2c64d8de309393ad7",
+        "title" => "another"
+      }
     ]
   }
 

--- a/apps/electric_cli/test/mocks/mock_server.ex
+++ b/apps/electric_cli/test/mocks/mock_server.ex
@@ -84,7 +84,7 @@ defmodule ElectricCli.MockServer do
         "encoding" => "escaped",
         "name" => "first_migration_name",
         "status" => "applied",
-        "original_body" => "",
+        "original_body" => "SELECT 1",
         "satellite_body" => ["something random"],
         "sha256" => "2a97d825e41ae70705381016921c55a3b086a813649e4da8fcba040710055747",
         "title" => "init"
@@ -92,7 +92,7 @@ defmodule ElectricCli.MockServer do
       %{
         "encoding" => "escaped",
         "name" => "second_migration_name",
-        "original_body" => "ORIGINAL",
+        "original_body" => "SELECT 2",
         "status" => "applied",
         "satellite_body" => ["other stuff"],
         "sha256" => "d0a52f739f137fc80fd67d9fd347cb4097bd6fb182e583f2c64d8de309393ad7",


### PR DESCRIPTION
When you init an app, you can sync migrations down from the server:

```sh
electric init APP --sync-down
```

And if you have an app already, you can revert all local migrations to match the server using:

```sh
electric migrations revert --all
```

Plus a bonus:

```sh
electric migrations revert NAME --force
```